### PR TITLE
Revert "Q1 2019 release notes"

### DIFF
--- a/ce19-ee114/ce1.9_release-notes.html
+++ b/ce19-ee114/ce1.9_release-notes.html
@@ -32,7 +32,6 @@
 <ul class="level1"><li><a href="#upgrade">Important Upgrade Information</a></li>
 <li><a href="#ce19-patches">Recent Patches</a></li>
 
-<li><a href="#ce19-1941">Magento Open Source 1.9.4.1 Release Notes</a></li>
 <li><a href="#ce19-1940">Magento Open Source 1.9.4.0 Release Notes</a></li>
 <li><a href="#ce19-19310">Magento Open Source 1.9.3.10 Release Notes</a></li>
 <li><a href="#ce19-1939">Magento Open Source 1.9.3.9 Release Notes</a></li>
@@ -60,54 +59,6 @@
 
 <h2 id="upgrade">Important Upgrade Information</h2>
 <div class="msg-box important"><img src="{{ site.baseurl }}/common/images/m1x/icon-important.png" alt="important" align="left" width="40"><span><strong>Important</strong>: Use Magento Open Source 1.9.3.0 or later for <em>all new Magento Open Source installations and upgrades</em> to get the latest fixes, features, and security updates.</span></div>
-
-<h2 id="ce19-1941">Magento Open Source 1.9.4.1 Release Notes</h2>
-
- <p>This version (or patch SUPEE-11086, which applies to older versions of Magento) provides resolution of multiple critical security issues and functional fixes. These security enhancements  help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. </p>
-
-<p>We recommend upgrading your Magento store to this latest version.  See  <a href="https://magento.com/security/patches/supee-11086" target="_blank">Magento Security Center</a> for a comprehensive discussion of these issues.</p>
-
-<p><b>Note</b>: Magento’s implementation of the Authorize.Net Direct Post payment method currently uses MD5-based hash for all M1 and M2 installations. As of June 28, 2019, Authorize.Net will stop supporting MD5-based hash usage. </p>
-
-<p>This will result in Magento merchants not being able to use Authorize.Net Direct Post  to process payments. To avoid disruption and to continue processing payments, merchants must apply a patch provided by Magento and add a Signature Key (SHA-512) in the Magento Admin configuration settings.  Magento released this patch in late February to address this issue on pre-2.3.1 installations of Magento. See [Update Authorize.Net Direct Post from MD5 to SHA-512](https://support.magento.com/hc/en-us/articles/360024368392-Update-Authorize-Net-Direct-Post-from-MD5-to-SHA-512). </p>
-
-<p>Information about the deprecation of Authorize.Net Direct Post can be found [here](https://docs.magento.com/m2/ce/user_guide/payment/authorize-net-direct-post.html).</p>
-
-<h3>Fixed issues and enhancements</h3>
-<ul>
-
-<li><!-- MPERF-10509 -->Google Image Charts has been replaced by Google Charts for dashboard charts. Google deprecated Google Image Charts on March 1, 2019.  </li>
-
-<li><!-- MPERF-9389 --> Layered navigation now works as expected when full page cache and block caching are enabled. Previously, you could not clear layered navigation filters when these features were enabled. </li>
-
-<li><!-- MPERF-9939 --> Errors caused by problematic PHP error logging have been resolved. Previously, Magento displayed excessive and unnecessary 404 errors. </li>
-
-<li><!-- MPERF-10340 --> Magento now displays the following message when an invalid character is used,  <code>Attribute code is invalid. Please use only letters (a-z), numbers (0-9) or underscore(_) in this field, first character should be a letter. Do not use "event" for an attribute code</code>. Previously, Magento did not flag invalid attribute codes. </li>
-
-<li><!-- MPERF-10361 --> You can now add to the cart products with custom options for which the <b>custom option</b> checkbox has not been checked. Previously, Magento did not add the product to the cart, and displayed this message, <code>Cannot add the item to shopping cart</code>.</li>
-
-<li><!-- MPERF-10265 --> URL redirects for products now work as expected. Previously, when you selected a product from the Category page and <bold>Add URL Redirect</bold> has been enabled, Magento redirected users to <bold>URL Redirect Information</bold> and threw this error, <code>exception 'Mage_Core_Exception' with message 'Invalid block type: Mage_Adminhtml_Block_Empty_Edit_Form' in app/Mage.php:580</code></li>
-
-<li><!-- MPERF-10318 --> Magento now displays payment information during the confirmation step of check out and successfully processes an order when inline translation is enabled. Previously, Magento did not display this payment information during check out, and the order was not completed.  </li>
-
-<li><!-- MPERF-10321 --> You can now create a staging website when development mode is enabled. Previously, Magento threw an error after you added a website from  <bold>System</bold> > <bold>Content Staging</bold> > <bold>Staging Websites</bold>. 
-</li>
-
-
-<li><!-- MPERF-10360 --> You can now successfully delete a website by clicking <b>Delete Website</b> as expected. Previously, when you clicked this button, Magento threw a fatal error. </li>
-
-<li><!-- MPERF-10397 --> You can now add a banner by clicking <b>Add Banner</b> from the Admin. Previously, Magento threw an error when you clicked this button. </li>
-
-<li><!-- MPERF-10415 --> Magento no longer throws an <code>Undefined index: is_recurring</code> error when when you try to save a product when deploying Magento with development mode enabled.  </li>
-
-</ul>
-
-<h3>Known issue</h3>
-<ul>
-<li>You cannot save custom widgets that were created by helper methods in layout updates.</li>
-</ul>
-
-
 
 
 

--- a/ce19-ee114/ee1.14_release-notes.html
+++ b/ce19-ee114/ee1.14_release-notes.html
@@ -26,8 +26,7 @@
 <div class="toc"> <h4 class="toc">Contents</h4>
 <p>These Release Notes contain the following information:</p>
 
-  <ul><li><a href="#upgrade">Important Upgrade Information</a></li>
-	<li><a href="#ee114-11441">Magento Commerce 1.14.4.1 Release Notes</a></li>
+<ul><li><a href="#upgrade">Important Upgrade Information</a></li>
 	<li><a href="#ee114-11440">Magento Commerce 1.14.4.0 Release Notes</a></li>
     <li><a href="#ee114-114310">Magento Commerce 1.14.3.10 Release Notes</a></li>
 	<li><a href="#ee114-11439">Magento Commerce 1.14.3.9 Release Notes</a></li>
@@ -54,59 +53,6 @@
 
 <h2 id="upgrade">Important Upgrade Information</h2>
 <div class="msg-box important"><img src="{{ site.baseurl }}/common/images/m1x/icon-important.png" alt="important" align="left" width="40"><span><strong>Important</strong>: Use Magento Commerce 1.14.3.0 or later for <em>all new Magento Commerce installations and upgrades</em> to get the latest fixes, features, and security updates.</span></div>
-
-
-
-<h2 id="ee114-11441">Magento Commerce 1.14.4.1 Release Notes</h2>
-
-<p>This version (or patch SUPEE-11086, which applies to older versions of Magento) provides resolution of multiple critical security issues and functional fixes. These security enhancements  help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. </p>
-</p>
-
-<p>We recommend upgrading your Magento store to this latest version.  See  <a href="https://magento.com/security/patches/supee-11086" target="_blank">Magento Security Center</a> for a comprehensive discussion of these issues.</p>
-
-
-<p><b>Note</b>: Magento’s implementation of the Authorize.Net Direct Post payment method currently uses MD5-based hash for all M1 and M2 installations. As of June 28, 2019, Authorize.Net will stop supporting MD5-based hash usage. </p>
-
-<p>This will result in Magento merchants not being able to use Authorize.Net Direct Post  to process payments. To avoid disruption and to continue processing payments, merchants must apply a patch provided by Magento and add a Signature Key (SHA-512) in the Magento Admin configuration settings.  Magento released this patch in late February to address this issue on pre-2.3.1 installations of Magento. See [Update Authorize.Net Direct Post from MD5 to SHA-512](https://support.magento.com/hc/en-us/articles/360024368392-Update-Authorize-Net-Direct-Post-from-MD5-to-SHA-512). </p>
-
-<p>Information about the deprecation of Authorize.Net Direct Post can be found [here](https://docs.magento.com/m2/ce/user_guide/payment/authorize-net-direct-post.html).</p>
-
-<h3>Fixed issues and enhancements</h3>
-<ul>
-<li><!-- MPERF-10509 -->Google Image Charts has been replaced by Google Charts for dashboard charts. Google deprecated Google Image Charts on March 1, 2019.  </li>
-
-
-<li><!-- MPERF-9389 --> Layered navigation now works as expected when full page cache and block caching are enabled. Previously, you could not clear layered navigation filters when these features were enabled. </li>
-
-<li><!-- MPERF-9939 --> Errors caused by problematic PHP error logging have been resolved. Previously, Magento displayed excessive and unnecessary 404 errors. </li>
-
-<li><!-- MPERF-10340 --> Magento now displays the following message when an invalid character is used,  <code>Attribute code is invalid. Please use only letters (a-z), numbers (0-9) or underscore(_) in this field, first character should be a letter. Do not use "event" for an attribute code</code>. Previously, Magento did not flag invalid attribute codes. </li>
-
-<li><!-- MPERF-10361 --> You can now add to the cart products with custom options for which the <b>custom option</b> checkbox has not been checked. Previously, Magento did not add the product to the cart, and displayed this message, <code>Cannot add the item to shopping cart</code>.</li>
-
-<li><!-- MPERF-10265 --> URL redirects for products now work as expected. Previously, when you selected a product from the Category page and <bold>Add URL Redirect</bold> has been enabled, Magento redirected users to <bold>URL Redirect Information</bold> and threw this error, <code>exception 'Mage_Core_Exception' with message 'Invalid block type: Mage_Adminhtml_Block_Empty_Edit_Form' in app/Mage.php:580</code></li>
-
-<li><!-- MPERF-10318 --> Magento now displays payment information during the confirmation step of check out and successfully processes an order when inline translation is enabled. Previously, Magento did not display this payment information during check out, and the order was not completed.  </li>
-
-<li><!-- MPERF-10321 --> You can now create a staging website when development mode is enabled. Previously, Magento threw an error after you added a website from  <bold>System</bold> > <bold>Content Staging</bold> > <bold>Staging Websites</bold>. 
-</li>
-
-
-<li><!-- MPERF-10360 --> You can now successfully delete a website by clicking <b>Delete Website</b> as expected. Previously, when you clicked this button, Magento threw a fatal error. </li>
-
-<li><!-- MPERF-10397 --> You can now add a banner by clicking <b>Add Banner</b> from the Admin. Previously, Magento threw an error when you clicked this button. </li>
-
-<li><!-- MPERF-10415 --> Magento no longer throws an <code>Undefined index: is_recurring</code> error when when you try to save a product when deploying Magento with development mode enabled.  </li>
-
-</ul>
-
-<h3>Known issue</h3>
-<ul>
-<li>You cannot save custom widgets that were created by helper methods in layout updates.</li>
-</ul>
-
-
-
 
 <h2 id="ee114-11440">Magento Commerce 1.14.4.0 Release Notes</h2>
 


### PR DESCRIPTION
Reverts magento/devdocs-m1#2

This should be merged on GA, otherwise our production build will pick it up and deploy it prematurely.