### PR TITLE
Magento 1.9.4.3/1.14.4.3 Release Notes

### DIFF
--- a/ce19-ee114/ce1.9_release-notes.html
+++ b/ce19-ee114/ce1.9_release-notes.html
@@ -76,7 +76,7 @@
 </ul>
 
 <h3>Known issue</h3>
-<p><!-- MPERF-10487 -->This release includes a fix for a security vulnerability that potentially exposed system configuration files to remote-code execution (RCE). This fix has resulted in the following vulnerability: An administrator with permission to edit configuration keys can exploit these undefined fields to permit the uploading and running of malicious code.</p>
+<p><!-- MPERF-10487 -->This release includes a fix for a security vulnerability that potentially allowed changes to protected store settings. As a result, extensions or customizations that depend on saving configuration fields that are not defined in <code>system.xml</code> files may no longer work correctly.</p>
 
 
 

--- a/ce19-ee114/ce1.9_release-notes.html
+++ b/ce19-ee114/ce1.9_release-notes.html
@@ -32,6 +32,7 @@
 <ul class="level1"><li><a href="#upgrade">Important Upgrade Information</a></li>
 <li><a href="#ce19-patches">Recent Patches</a></li>
 
+<li><a href="#ce19-1943">Magento Open Source 1.9.4.3 Release Notes</a></li>
 <li><a href="#ce19-1942">Magento Open Source 1.9.4.2 Release Notes</a></li>
 <li><a href="#ce19-1941">Magento Open Source 1.9.4.1 Release Notes</a></li>
 <li><a href="#ce19-1940">Magento Open Source 1.9.4.0 Release Notes</a></li>
@@ -61,6 +62,23 @@
 
 <h2 id="upgrade">Important Upgrade Information</h2>
 <div class="msg-box important"><img src="{{ site.baseurl }}/guides/m1x/images/icon-important.png" alt="important" align="left" width="40"><span><strong>Important</strong>: Use Magento Open Source 1.9.3.0 or later for <em>all new Magento Open Source installations and upgrades</em> to get the latest fixes, features, and security updates.</span></div>
+
+<h2 id="ce19-1943">Magento Open Source 1.9.4.3 Release Notes</h2>
+
+<p>This version (or patch SUPEE-11219, which applies to older versions of Magento) provides resolution of multiple critical security issues and functional fixes. These security enhancements  help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. </p>
+
+<p>We recommend upgrading your Magento store to this latest version.  See  <a href="https://magento.com/security/patches/supee-11219" target="_blank">Magento Security Center</a> for a comprehensive discussion of these issues.</p>
+
+<h3>Fixed issues and enhancements</h3>
+<ul>
+<li>WebserviceX has been removed from the Magento 1.x code base. </li>
+<li>This release adds two new currency services for currency rate import: <a href="https://www.currencyconverterapi.com/" target="_blank">CurrencyConverterAPI</a> and <a href="https://fixer.io/” target="_blank">FixerIO</a></li>
+</ul>
+
+<h3>Known issue</h3>
+<p><!-- MPERF-10487 -->This release includes a fix for a security vulnerability that potentially exposed system configuration files to remote-code execution (RCE). This fix has resulted in the following vulnerability: An administrator with permission to edit configuration keys can exploit these undefined fields to permit the uploading and running of malicious code.</p>
+
+
 
 <h2 id="ce19-1942">Magento Open Source 1.9.4.2 Release Notes</h2>
 <p>This version (or patch SUPEE-11155, which applies to older versions of Magento) provides resolution of multiple critical security issues and functional fixes. These security enhancements  help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. </p>

--- a/ce19-ee114/ee1.14_release-notes.html
+++ b/ce19-ee114/ee1.14_release-notes.html
@@ -27,6 +27,8 @@
 <p>These Release Notes contain the following information:</p>
 
   <ul><li><a href="#upgrade">Important Upgrade Information</a></li>
+
+	<li><a href="#ee114-11443">Magento Commerce 1.14.4.3 Release Notes</a></li>
 	<li><a href="#ee114-11442">Magento Commerce 1.14.4.2 Release Notes</a></li>
 	<li><a href="#ee114-11441">Magento Commerce 1.14.4.1 Release Notes</a></li>
 	<li><a href="#ee114-11440">Magento Commerce 1.14.4.0 Release Notes</a></li>
@@ -55,6 +57,22 @@
 
 <h2 id="upgrade">Important Upgrade Information</h2>
 <div class="msg-box important"><img src="{{ site.baseurl }}/guides/m1x/images/icon-important.png" alt="important" align="left" width="40"><span><strong>Important</strong>: Use Magento Commerce 1.14.3.0 or later for <em>all new Magento Commerce installations and upgrades</em> to get the latest fixes, features, and security updates.</span></div>
+
+<h2 id="ee114-11443">Magento Commerce 1.14.4.3 Release Notes</h2>
+
+<p>This version (or patch SUPEE-11219, which applies to older versions of Magento) provides resolution of multiple critical security issues and functional fixes. These security enhancements  help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. </p>
+
+<p>We recommend upgrading your Magento store to this latest version.  See  <a href="https://magento.com/security/patches/supee-11219" target="_blank">Magento Security Center</a> for a comprehensive discussion of these issues.</p>
+
+<h3>Fixed issues and enhancements</h3>
+<ul>
+<li>WebserviceX has been removed from the Magento 1.x code base. </li>
+<li>This release adds two new currency services for currency rate import: <a href="https://www.currencyconverterapi.com/" target="_blank">CurrencyConverterAPI</a> and <a href="https://fixer.io/” target="_blank">FixerIO</a></li>
+</ul>
+
+<h3>Known issue</h3>
+<p><!-- MPERF-10487 -->This release includes a fix for a security vulnerability that potentially exposed system configuration files to remote-code execution (RCE). This fix has resulted in the following vulnerability: An administrator with permission to edit configuration keys can exploit these undefined fields to permit the uploading and running of malicious code.</p>
+
 
 
 

--- a/ce19-ee114/ee1.14_release-notes.html
+++ b/ce19-ee114/ee1.14_release-notes.html
@@ -71,7 +71,7 @@
 </ul>
 
 <h3>Known issue</h3>
-<p><!-- MPERF-10487 -->This release includes a fix for a security vulnerability that potentially exposed system configuration files to remote-code execution (RCE). This fix has resulted in the following vulnerability: An administrator with permission to edit configuration keys can exploit these undefined fields to permit the uploading and running of malicious code.</p>
+<p><!-- MPERF-10487 -->This release includes a fix for a security vulnerability that potentially allowed changes to protected store settings. As a result, extensions or customizations that depend on saving configuration fields that are not defined in <code>system.xml</code> files may no longer work correctly.</p>
 
 
 


### PR DESCRIPTION
This PR adds release notes for the Magento Open Source 1.9.4.3 and Magento Commerce 1.14.4.3.

https://devdocs.magento.com/guides/m1x/ce19-ee114/ce1.9_release-notes.html
https://devdocs.magento.com/guides/m1x/ce19-ee114/ee1.14_release-notes.html

whatsnew