### PR TITLE
Remove redundant and vulnerable php script

### DIFF
--- a/api/rest/Resources/Orders/order_comments.html
+++ b/api/rest/Resources/Orders/order_comments.html
@@ -145,4 +145,4 @@ title: Order Comments
 
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/Orders/order_items.html
+++ b/api/rest/Resources/Orders/order_items.html
@@ -175,4 +175,4 @@ title: Order Items
 
 				    
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/Orders/sales_orders.html
+++ b/api/rest/Resources/Orders/sales_orders.html
@@ -364,4 +364,4 @@ The list of attributes that will be returned for the order is configured in the 
 
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/Products/product_categories.html
+++ b/api/rest/Resources/Products/product_categories.html
@@ -152,4 +152,4 @@ title: Product Categories
 </tbody></table>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/Products/product_images.html
+++ b/api/rest/Resources/Products/product_images.html
@@ -648,4 +648,4 @@ title: Product Images
 </tbody></table>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/Products/product_websites.html
+++ b/api/rest/Resources/Products/product_websites.html
@@ -484,4 +484,4 @@ title: Product Websites
 
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/Products/products.html
+++ b/api/rest/Resources/Products/products.html
@@ -1066,4 +1066,4 @@ PUT for specific store http://magentohost/api/rest/products/8/store/3</td></tr><
 
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/get_filters.html
+++ b/api/rest/Resources/get_filters.html
@@ -68,4 +68,4 @@ title: GET Filters
 <p><a href="http://magentohost/api/rest/products/?order=entity_id&amp;filter\[0\]\[attribute\]=description&amp;filter\[0\]\[in\]\[0\]=simple01">http://magentohost/api/rest/products/?order=entity_id&amp;filter[0][attribute]=description&amp;filter[0][in][0]=simple01</a></p>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/inventory.html
+++ b/api/rest/Resources/inventory.html
@@ -623,4 +623,4 @@ title: Inventory
 </table>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/resource_customer_addresses.html
+++ b/api/rest/Resources/resource_customer_addresses.html
@@ -507,4 +507,4 @@ JSON responses on this page contributed by Tim Reynolds
 </tbody></table>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/resource_customers.html
+++ b/api/rest/Resources/resource_customers.html
@@ -379,4 +379,4 @@ You must specify only those parameters which you want to update. Parameters that
 <div class='panelMacro'><table class='infoMacro'><tr><td>DELETE http://magentohost/api/rest/customers/2</td></tr></table></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/Resources/resources.html
+++ b/api/rest/Resources/resources.html
@@ -97,4 +97,4 @@ title: Resources
 
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/common_http_status_codes.html
+++ b/api/rest/common_http_status_codes.html
@@ -98,4 +98,4 @@ Resource internal error. </td>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/get_filters.html
+++ b/api/rest/get_filters.html
@@ -74,4 +74,4 @@ title: GET Filters
 
 <p><a href="http://magentohost/api/rest/customers?filter\[1\]\[attribute\]=email&amp;filter\[1\]\[in\]\[0\]=ryan@test.com">http://magentohost/api/rest/customers?filter[1][attribute]=email&amp;filter[1][in][0]=ryan@test.com</a></p>
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/http_methods.html
+++ b/api/rest/http_methods.html
@@ -87,4 +87,4 @@ title: HTTP Methods
 <p>Deleting a resource is performed by means of making an HTTP DELETE request to the resource URL.</p>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/introduction.html
+++ b/api/rest/introduction.html
@@ -507,4 +507,4 @@ The BlackBerry 8100 Pearl sports a large 240 x 260 screen that supports over 65,
     <li>oauth_version - OAuth version.</li>
 </ul>
 <br />
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/rest/permission_settings/permission_settings.html
+++ b/api/rest/permission_settings/permission_settings.html
@@ -108,4 +108,4 @@ Each ACL entry specifies two instances: a subject and an action the subject can 
 
 				    					    <br/>
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/rest/response_formats.html
+++ b/api/rest/response_formats.html
@@ -163,4 +163,4 @@ To set the response format to JSON, add the Accept request header with the appli
 <p>The list of HTTP status codes that are returned in the API response is described in the <a href="http://www.magentocommerce.com/api/rest/common_http_status_codes.html" title="Common HTTP Status Codes">Common HTTP Status Codes</a> part of the documentation. There, you can find the list of codes themselves together with their description.</p>
 
 				    
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalog.html
+++ b/api/soap/catalog/catalog.html
@@ -310,4 +310,3 @@ title: Catalog
 	<li><a href="catalogProductCustomOptionValue/product_custom_option_value.update.html" title="product_custom_option_value.update">product_custom_option_value.update</a> - Update the custom option value</li>
 	<li><a href="catalogProductCustomOptionValue/product_custom_option_value.remove.html" title="product_custom_option_value.remove">product_custom_option_value.remove</a> - Remove the custom option value</li>
 </ul>
-<?php include(__ROOT__ . 'footer.php'); ?>

--- a/api/soap/catalog/catalogCategory/catalogCategory.html
+++ b/api/soap/catalog/catalogCategory/catalogCategory.html
@@ -148,4 +148,3 @@ $proxy-&gt;call($sessionId, 'category.updateProduct', array($categoryId, 'somePr
 $proxy-&gt;call($sessionId, 'category.removeProduct', array($categoryId, 'someProductSku'));</pre>
 		</div>
 </div></div>
-<?php include(__ROOT__ . 'footer.php'); ?>

--- a/api/soap/catalog/catalogCategory/catalog_category.assignProduct.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.assignProduct.html
@@ -130,4 +130,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategory/catalog_category.assignedProducts.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.assignedProducts.html
@@ -172,4 +172,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategory/catalog_category.create.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.create.html
@@ -302,4 +302,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategory/catalog_category.currentStore.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.currentStore.html
@@ -100,4 +100,4 @@ var_dump($result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/soap/catalog/catalogCategory/catalog_category.delete.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.delete.html
@@ -114,4 +114,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategory/catalog_category.info.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.info.html
@@ -341,4 +341,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategory/catalog_category.move.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.move.html
@@ -130,4 +130,4 @@ var_dump($result-&gt;result);</pre>
 <p><b>Note</b>: Please make sure that you are not moving the category to any of its own children. There are no extra checks to prevent doing it through API, and you won’t be able to fix this from the admin interface later.</p>
 
 				    
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategory/catalog_category.removeProduct.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.removeProduct.html
@@ -126,4 +126,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategory/catalog_category.tree.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.tree.html
@@ -248,4 +248,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategory/catalog_category.update.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.update.html
@@ -303,4 +303,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategory/catalog_category.updateProduct.html
+++ b/api/soap/catalog/catalogCategory/catalog_category.updateProduct.html
@@ -132,4 +132,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.currentStore.html
+++ b/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.currentStore.html
@@ -99,4 +99,4 @@ var_dump($result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>		    
+		    

--- a/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.list.html
+++ b/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.list.html
@@ -176,4 +176,4 @@ var_dump ($result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.options.html
+++ b/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.options.html
@@ -157,4 +157,4 @@ var_dump ($result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogCategoryAttributes/categoryAttributes.html
+++ b/api/soap/catalog/catalogCategoryAttributes/categoryAttributes.html
@@ -64,4 +64,3 @@ foreach ($attributes as &amp;$attribute) {
 var_dump($attributes);</pre>
 		</div>
 </div></div>
-<?php include(__ROOT__ . 'footer.php'); ?>

--- a/api/soap/catalog/catalogProduct/catalog_product.create.html
+++ b/api/soap/catalog/catalogProduct/catalog_product.create.html
@@ -513,4 +513,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProduct/catalog_product.delete.html
+++ b/api/soap/catalog/catalogProduct/catalog_product.delete.html
@@ -121,4 +121,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProduct/catalog_product.getSpecialPrice.html
+++ b/api/soap/catalog/catalogProduct/catalog_product.getSpecialPrice.html
@@ -162,4 +162,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProduct/catalog_product.info.html
+++ b/api/soap/catalog/catalogProduct/catalog_product.info.html
@@ -441,4 +441,4 @@ The PowerShot A630 packs a vast array of advanced features into a remarkably com
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProduct/catalog_product.list.html
+++ b/api/soap/catalog/catalogProduct/catalog_product.list.html
@@ -221,4 +221,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProduct/catalog_product.listOfAdditionalAttributes.html
+++ b/api/soap/catalog/catalogProduct/catalog_product.listOfAdditionalAttributes.html
@@ -160,4 +160,4 @@ var_dump($result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProduct/catalog_product.setSpecialPrice.html
+++ b/api/soap/catalog/catalogProduct/catalog_product.setSpecialPrice.html
@@ -142,4 +142,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProduct/catalog_product.update.html
+++ b/api/soap/catalog/catalogProduct/catalog_product.update.html
@@ -479,4 +479,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttribute/catalog_product_attribute.options.html
+++ b/api/soap/catalog/catalogProductAttribute/catalog_product_attribute.options.html
@@ -182,4 +182,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttribute/product_attribute.list.html
+++ b/api/soap/catalog/catalogProductAttribute/product_attribute.list.html
@@ -180,4 +180,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttribute/product_attribute.options.html
+++ b/api/soap/catalog/catalogProductAttribute/product_attribute.options.html
@@ -182,4 +182,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttribute/product_attribute.remove.html
+++ b/api/soap/catalog/catalogProductAttribute/product_attribute.remove.html
@@ -121,4 +121,4 @@ var_dump ($result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.create.html
+++ b/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.create.html
@@ -223,4 +223,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.info.html
+++ b/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.info.html
@@ -194,4 +194,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.list.html
+++ b/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.list.html
@@ -191,4 +191,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.remove.html
+++ b/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.remove.html
@@ -127,4 +127,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.types.html
+++ b/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.types.html
@@ -158,4 +158,3 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>

--- a/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.update.html
+++ b/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.update.html
@@ -231,4 +231,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeAdd.html
+++ b/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeAdd.html
@@ -157,4 +157,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeRemove.html
+++ b/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeRemove.html
@@ -136,4 +136,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.create.html
+++ b/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.create.html
@@ -139,4 +139,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupAdd.html
+++ b/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupAdd.html
@@ -125,4 +125,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRemove.html
+++ b/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRemove.html
@@ -127,4 +127,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRename.html
+++ b/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRename.html
@@ -127,4 +127,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.list.html
+++ b/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.list.html
@@ -152,4 +152,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.remove.html
+++ b/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.remove.html
@@ -131,4 +131,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOption/product_custom_option.add.html
+++ b/api/soap/catalog/catalogProductCustomOption/product_custom_option.add.html
@@ -332,4 +332,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOption/product_custom_option.info.html
+++ b/api/soap/catalog/catalogProductCustomOption/product_custom_option.info.html
@@ -259,4 +259,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOption/product_custom_option.list.html
+++ b/api/soap/catalog/catalogProductCustomOption/product_custom_option.list.html
@@ -174,4 +174,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOption/product_custom_option.remove.html
+++ b/api/soap/catalog/catalogProductCustomOption/product_custom_option.remove.html
@@ -118,4 +118,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOption/product_custom_option.types.html
+++ b/api/soap/catalog/catalogProductCustomOption/product_custom_option.types.html
@@ -168,4 +168,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOption/product_custom_option.update.html
+++ b/api/soap/catalog/catalogProductCustomOption/product_custom_option.update.html
@@ -312,4 +312,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.add.html
+++ b/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.add.html
@@ -195,4 +195,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.info.html
+++ b/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.info.html
@@ -215,4 +215,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.list.html
+++ b/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.list.html
@@ -194,4 +194,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.remove.html
+++ b/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.remove.html
@@ -128,4 +128,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.update.html
+++ b/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.update.html
@@ -206,4 +206,3 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>

--- a/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.add.html
+++ b/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.add.html
@@ -351,4 +351,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.list.html
+++ b/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.list.html
@@ -352,4 +352,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 				    
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.remove.html
+++ b/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.remove.html
@@ -133,4 +133,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductLink/catalog_product_link.assign.html
+++ b/api/soap/catalog/catalogProductLink/catalog_product_link.assign.html
@@ -173,4 +173,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductLink/catalog_product_link.attributes.html
+++ b/api/soap/catalog/catalogProductLink/catalog_product_link.attributes.html
@@ -147,4 +147,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductLink/catalog_product_link.list.html
+++ b/api/soap/catalog/catalogProductLink/catalog_product_link.list.html
@@ -189,4 +189,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductLink/catalog_product_link.remove.html
+++ b/api/soap/catalog/catalogProductLink/catalog_product_link.remove.html
@@ -127,4 +127,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductLink/catalog_product_link.types.html
+++ b/api/soap/catalog/catalogProductLink/catalog_product_link.types.html
@@ -124,4 +124,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductLink/catalog_product_link.update.html
+++ b/api/soap/catalog/catalogProductLink/catalog_product_link.update.html
@@ -201,4 +201,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductTag/product_tag.add.html
+++ b/api/soap/catalog/catalogProductTag/product_tag.add.html
@@ -176,4 +176,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductTag/product_tag.info.html
+++ b/api/soap/catalog/catalogProductTag/product_tag.info.html
@@ -171,4 +171,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductTag/product_tag.list.html
+++ b/api/soap/catalog/catalogProductTag/product_tag.list.html
@@ -160,4 +160,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductTag/product_tag.remove.html
+++ b/api/soap/catalog/catalogProductTag/product_tag.remove.html
@@ -116,4 +116,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductTag/product_tag.update.html
+++ b/api/soap/catalog/catalogProductTag/product_tag.update.html
@@ -169,4 +169,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.info.html
+++ b/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.info.html
@@ -197,4 +197,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.update.html
+++ b/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.update.html
@@ -185,4 +185,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalog/catalogProductTypes/catalog_product_type.list.html
+++ b/api/soap/catalog/catalogProductTypes/catalog_product_type.list.html
@@ -166,4 +166,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalogInventory/cataloginventory_stock_item.list.html
+++ b/api/soap/catalogInventory/cataloginventory_stock_item.list.html
@@ -163,4 +163,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/catalogInventory/cataloginventory_stock_item.update.html
+++ b/api/soap/catalogInventory/cataloginventory_stock_item.update.html
@@ -236,4 +236,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cart/cart.create.html
+++ b/api/soap/checkout/cart/cart.create.html
@@ -102,4 +102,4 @@ var_dump($result-&gt;result);</pre>
 
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cart/cart.html
+++ b/api/soap/checkout/cart/cart.html
@@ -209,4 +209,3 @@ if (count($shoppingCartLicenses)) {
 $resultOrderCreation = $proxy-&gt;call($sessionId,"cart.order",array($shoppingCartId, null, $licenseForOrderCreation));</pre>
 		</div>
 </div></div>
-<?php include(__ROOT__ . 'footer.php'); ?>

--- a/api/soap/checkout/cart/cart.info.html
+++ b/api/soap/checkout/cart/cart.info.html
@@ -941,4 +941,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cart/cart.license.html
+++ b/api/soap/checkout/cart/cart.license.html
@@ -161,4 +161,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 				    
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cart/cart.order.html
+++ b/api/soap/checkout/cart/cart.order.html
@@ -171,4 +171,4 @@ $password = 'apiKey';
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cart/cart.totals.html
+++ b/api/soap/checkout/cart/cart.totals.html
@@ -160,4 +160,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartCoupon/cart_coupon.add.html
+++ b/api/soap/checkout/cartCoupon/cart_coupon.add.html
@@ -116,4 +116,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartCoupon/cart_coupon.remove.html
+++ b/api/soap/checkout/cartCoupon/cart_coupon.remove.html
@@ -107,4 +107,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartCustomer/cart_customer.addresses.html
+++ b/api/soap/checkout/cartCustomer/cart_customer.addresses.html
@@ -251,4 +251,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartCustomer/cart_customer.set.html
+++ b/api/soap/checkout/cartCustomer/cart_customer.set.html
@@ -175,4 +175,4 @@ $resultCustomerSet = $client-&gt;shoppingCartCustomerSet($session, $quoteId, $cu
 </div></div>
 
 				    
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartPayment/cart_payment.method.html
+++ b/api/soap/checkout/cartPayment/cart_payment.method.html
@@ -196,4 +196,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartProduct/cart_product.add.html
+++ b/api/soap/checkout/cartProduct/cart_product.add.html
@@ -200,4 +200,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartProduct/cart_product.list.html
+++ b/api/soap/checkout/cartProduct/cart_product.list.html
@@ -177,4 +177,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartProduct/cart_product.remove.html
+++ b/api/soap/checkout/cartProduct/cart_product.remove.html
@@ -211,4 +211,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartProduct/cart_product.update.html
+++ b/api/soap/checkout/cartProduct/cart_product.update.html
@@ -209,4 +209,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartShipping/cart_shipping.list.html
+++ b/api/soap/checkout/cartShipping/cart_shipping.list.html
@@ -158,4 +158,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/cartShipping/cart_shipping.method.html
+++ b/api/soap/checkout/cartShipping/cart_shipping.method.html
@@ -116,4 +116,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/checkout/checkout.html
+++ b/api/soap/checkout/checkout.html
@@ -89,4 +89,3 @@ title: Checkout
 	<li><a href="cart/cart.totals.html" title="cart.totals">cart.totals</a> - Get all available prices for items in shopping cart, using additional parameters</li>
 	<li><a href="cart/cart.license.html" title="cart.license">cart.license</a> - Get website license agreement</li>
 </ul>
-<?php include(__ROOT__ . 'footer.php'); ?>

--- a/api/soap/create_your_own_api.html
+++ b/api/soap/create_your_own_api.html
@@ -600,4 +600,4 @@ title: Create Your Own API
 </div>
 
 <p> If you are missing this method, the error "Invalid API path" will be returned. </p>
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customer.create.html
+++ b/api/soap/customer/customer.create.html
@@ -190,4 +190,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customer.delete.html
+++ b/api/soap/customer/customer.delete.html
@@ -101,4 +101,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customer.html
+++ b/api/soap/customer/customer.html
@@ -101,4 +101,3 @@ $proxy-&gt;call($sessionId, 'customer.delete', $newCustomerId);</pre>
 <ul>
 	<li><a href="customer_group.html" title="customer_group.list">customer_group.list</a> &#45; Retrieve the list of customer groups</li>
 </ul>
-<?php include(__ROOT__ . 'footer.php'); ?>

--- a/api/soap/customer/customer.info.html
+++ b/api/soap/customer/customer.info.html
@@ -256,4 +256,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customer.list.html
+++ b/api/soap/customer/customer.list.html
@@ -272,4 +272,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customer.update.html
+++ b/api/soap/customer/customer.update.html
@@ -185,4 +185,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customerAddress/customer_address.create.html
+++ b/api/soap/customer/customerAddress/customer_address.create.html
@@ -213,4 +213,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customerAddress/customer_address.delete.html
+++ b/api/soap/customer/customerAddress/customer_address.delete.html
@@ -100,4 +100,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customerAddress/customer_address.info.html
+++ b/api/soap/customer/customerAddress/customer_address.info.html
@@ -251,4 +251,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customerAddress/customer_address.list.html
+++ b/api/soap/customer/customerAddress/customer_address.list.html
@@ -256,4 +256,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customerAddress/customer_address.update.html
+++ b/api/soap/customer/customerAddress/customer_address.update.html
@@ -212,4 +212,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/customer/customer_group.html
+++ b/api/soap/customer/customer_group.html
@@ -143,4 +143,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/directory/directory.html
+++ b/api/soap/directory/directory.html
@@ -41,4 +41,3 @@ title: Directory
 <ul>
 	<li><a href="directory_region.list.html" title="directory_region.list">directory_region.list</a> &#45; Retrieve a list of regions in a specified country</li>
 </ul>
-<?php include(__ROOT__ . 'footer.php'); ?>

--- a/api/soap/directory/directory_country.list.html
+++ b/api/soap/directory/directory_country.list.html
@@ -163,4 +163,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/directory/directory_region.list.html
+++ b/api/soap/directory/directory_region.list.html
@@ -183,4 +183,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.add.html
+++ b/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.add.html
@@ -144,4 +144,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.list.html
+++ b/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.list.html
@@ -187,4 +187,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.remove.html
+++ b/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.remove.html
@@ -142,4 +142,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftCard/enterprise_giftCard.html
+++ b/api/soap/enterpriseGiftCard/enterprise_giftCard.html
@@ -55,5 +55,5 @@ title: Enterprise Gift Card
 
 
 				    
-<?php include(__ROOT__ . 'footer.php'); ?>
+
                     			    

--- a/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.create.html
+++ b/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.create.html
@@ -224,4 +224,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.info.html
+++ b/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.info.html
@@ -246,4 +246,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.list.html
+++ b/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.list.html
@@ -219,4 +219,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.remove.html
+++ b/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.remove.html
@@ -122,4 +122,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.update.html
+++ b/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.update.html
@@ -177,4 +177,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.info.html
+++ b/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.info.html
@@ -154,4 +154,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.redeem.html
+++ b/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.redeem.html
@@ -143,4 +143,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftMessage/giftmessage.setForQuote.html
+++ b/api/soap/enterpriseGiftMessage/giftmessage.setForQuote.html
@@ -183,4 +183,4 @@ var_dump($result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteItem.html
+++ b/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteItem.html
@@ -184,4 +184,4 @@ var_dump($result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteProduct.html
+++ b/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteProduct.html
@@ -269,4 +269,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterprise_customerbalance/customerBalance/storecredit.balance.html
+++ b/api/soap/enterprise_customerbalance/customerBalance/storecredit.balance.html
@@ -122,4 +122,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterprise_customerbalance/customerBalance/storecredit.history.html
+++ b/api/soap/enterprise_customerbalance/customerBalance/storecredit.history.html
@@ -224,4 +224,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 				    
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.removeAmount.html
+++ b/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.removeAmount.html
@@ -130,4 +130,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.setAmount.html
+++ b/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.setAmount.html
@@ -131,4 +131,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/introduction.html
+++ b/api/soap/introduction.html
@@ -243,4 +243,4 @@ $result = $client-&gt;salesOrderList($sessionId, $params);</pre>
 <p>Using the WS-I compliant SOAP v2 API WSDL, it is easy to automatically generate client classes for Java, .NET, and other languages using standard libraries. </p>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/miscellaneous/magento.info.html
+++ b/api/soap/miscellaneous/magento.info.html
@@ -115,4 +115,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/miscellaneous/store.info.html
+++ b/api/soap/miscellaneous/store.info.html
@@ -179,4 +179,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/miscellaneous/store.list.html
+++ b/api/soap/miscellaneous/store.list.html
@@ -171,4 +171,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrder/salesOrder.html
+++ b/api/soap/sales/salesOrder/salesOrder.html
@@ -91,5 +91,5 @@ var_dump($proxy-&gt;call($sessionId, 'sales_order.info', '100000003'));</pre>
 </div></div>
 
 				    
-<?php include(__ROOT__ . 'footer.php'); ?>
+
                     			    

--- a/api/soap/sales/salesOrder/sales_order.addComment.html
+++ b/api/soap/sales/salesOrder/sales_order.addComment.html
@@ -131,4 +131,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrder/sales_order.cancel.html
+++ b/api/soap/sales/salesOrder/sales_order.cancel.html
@@ -113,4 +113,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrder/sales_order.hold.html
+++ b/api/soap/sales/salesOrder/sales_order.hold.html
@@ -115,4 +115,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrder/sales_order.info.html
+++ b/api/soap/sales/salesOrder/sales_order.info.html
@@ -1185,4 +1185,4 @@ English' (length=29)
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrder/sales_order.list.html
+++ b/api/soap/sales/salesOrder/sales_order.list.html
@@ -547,4 +547,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrder/sales_order.unhold.html
+++ b/api/soap/sales/salesOrder/sales_order.unhold.html
@@ -109,4 +109,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderCreditMemo/salesOrderCreditMemo.html
+++ b/api/soap/sales/salesOrderCreditMemo/salesOrderCreditMemo.html
@@ -111,5 +111,5 @@ print_r($creditmemoList);</pre>
 </div></div>
 
 				    
-<?php include(__ROOT__ . 'footer.php'); ?>
+
                     			    

--- a/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.addComment.html
+++ b/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.addComment.html
@@ -128,4 +128,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.create.html
+++ b/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.create.html
@@ -216,4 +216,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.info.html
+++ b/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.info.html
@@ -882,4 +882,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.list.html
+++ b/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.list.html
@@ -837,4 +837,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderInvoice/sales_order_invoice.addComment.html
+++ b/api/soap/sales/salesOrderInvoice/sales_order_invoice.addComment.html
@@ -127,4 +127,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderInvoice/sales_order_invoice.capture.html
+++ b/api/soap/sales/salesOrderInvoice/sales_order_invoice.capture.html
@@ -153,4 +153,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderInvoice/sales_order_invoice.create.html
+++ b/api/soap/sales/salesOrderInvoice/sales_order_invoice.create.html
@@ -172,4 +172,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderInvoice/sales_order_invoice.info.html
+++ b/api/soap/sales/salesOrderInvoice/sales_order_invoice.info.html
@@ -586,4 +586,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderInvoice/sales_order_invoice.list.html
+++ b/api/soap/sales/salesOrderInvoice/sales_order_invoice.list.html
@@ -211,4 +211,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderShipment/sales_order_shipment.addComment.html
+++ b/api/soap/sales/salesOrderShipment/sales_order_shipment.addComment.html
@@ -128,4 +128,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html
+++ b/api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html
@@ -133,4 +133,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderShipment/sales_order_shipment.create.html
+++ b/api/soap/sales/salesOrderShipment/sales_order_shipment.create.html
@@ -198,4 +198,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderShipment/sales_order_shipment.getCarriers.html
+++ b/api/soap/sales/salesOrderShipment/sales_order_shipment.getCarriers.html
@@ -130,4 +130,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderShipment/sales_order_shipment.info.html
+++ b/api/soap/sales/salesOrderShipment/sales_order_shipment.info.html
@@ -318,4 +318,4 @@ var_dump($result-&gt;result);</pre>
 		</div>
 </div></div>
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderShipment/sales_order_shipment.list.html
+++ b/api/soap/sales/salesOrderShipment/sales_order_shipment.list.html
@@ -190,4 +190,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 				    
-<?php include(__ROOT__ . 'footer.php'); ?>
+

--- a/api/soap/sales/salesOrderShipment/sales_order_shipment.removeTrack.html
+++ b/api/soap/sales/salesOrderShipment/sales_order_shipment.removeTrack.html
@@ -123,4 +123,4 @@ var_dump($result-&gt;result);</pre>
 </div></div>
 
 
-<?php include(__ROOT__ . 'footer.php'); ?>
+


### PR DESCRIPTION
Many pages contain redundant script `<?php include(__ROOT__ . 'footer.php'); ?>`.
It is possible that it was used in the past.
Removing the script entirely.