### PR TITLE
Magento Open Source 1.9.4.5 and Magento Commerce 1.14.9.5 Release Notes

### DIFF
--- a/ce19-ee114/ce1.9_release-notes.html
+++ b/ce19-ee114/ce1.9_release-notes.html
@@ -32,6 +32,7 @@
 <ul class="level1"><li><a href="#upgrade">Important Upgrade Information</a></li>
 <li><a href="#ce19-patches">Recent Patches</a></li>
 
+<li><a href="#ce19-1945">Magento Open Source 1.9.4.5 Release Notes</a></li>
 <li><a href="#ce19-1944">Magento Open Source 1.9.4.4 Release Notes</a></li>
 <li><a href="#ce19-1943">Magento Open Source 1.9.4.3 Release Notes</a></li>
 <li><a href="#ce19-1942">Magento Open Source 1.9.4.2 Release Notes</a></li>
@@ -63,6 +64,13 @@
 
 <h2 id="upgrade">Important Upgrade Information</h2>
 <div class="msg-box important"><img src="{{ site.baseurl }}/guides/m1x/images/icon-important.png" alt="important" align="left" width="40"><span><strong>Important</strong>: Use Magento Open Source 1.9.3.0 or later for <em>all new Magento Open Source installations and upgrades</em> to get the latest fixes, features, and security updates.</span></div>
+
+
+<h2 id="ce19-1945">Magento Open Source 1.9.4.5 Release Notes</h2>
+
+<p>This version (or patch SUPEE-11314, which applies to older versions of Magento) provides resolution of multiple critical security issues. These security enhancements help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. </p>
+
+<p>We recommend upgrading your Magento store to this latest version.  See  <a href="https://helpx.adobe.com/security/products/magento/apsb20-22.html" target="_blank">Magento | APSB20-22</a> for a comprehensive discussion of these issues.</p>
 
 
 <h2 id="ce19-1944">Magento Open Source 1.9.4.4 Release Notes</h2>

--- a/ce19-ee114/ee1.14_release-notes.html
+++ b/ce19-ee114/ee1.14_release-notes.html
@@ -26,8 +26,9 @@
 <div class="toc"> <h4 class="toc">Contents</h4>
 <p>These Release Notes contain the following information:</p>
 
-  <ul><li><a href="#upgrade">Important Upgrade Information</a></li>
+<ul><li><a href="#upgrade">Important Upgrade Information</a></li>
 
+	<li><a href="#ee114-11445">Magento Commerce 1.14.4.5 Release Notes</a></li>
 	<li><a href="#ee114-11444">Magento Commerce 1.14.4.4 Release Notes</a></li>
 	<li><a href="#ee114-11443">Magento Commerce 1.14.4.3 Release Notes</a></li>
 	<li><a href="#ee114-11442">Magento Commerce 1.14.4.2 Release Notes</a></li>
@@ -58,6 +59,12 @@
 
 <h2 id="upgrade">Important Upgrade Information</h2>
 <div class="msg-box important"><img src="{{ site.baseurl }}/guides/m1x/images/icon-important.png" alt="important" align="left" width="40"><span><strong>Important</strong>: Use Magento Commerce 1.14.3.0 or later for <em>all new Magento Commerce installations and upgrades</em> to get the latest fixes, features, and security updates.</span></div>
+
+<h2 id="ee114-11445">Magento Commerce 1.14.4.5 Release Notes</h2>
+
+<p>This version (or patch SUPEE-11314, which applies to older versions of Magento) provides resolution of multiple critical security issues. These security enhancements help close cross-site scripting, arbitrary code execution, and sensitive data disclosure vulnerabilities as well as other security issues. </p>
+<p>We recommend upgrading your Magento store to this latest version.  See  <a href="https://helpx.adobe.com/security/products/magento/apsb20-22.html" target="_blank">Magento | APSB20-22</a> for a comprehensive discussion of these issues.</p>
+
 
 
 <h2 id="ee114-11444">Magento Commerce 1.14.4.4 Release Notes</h2>


### PR DESCRIPTION
This PR merges the Magento 1x release notes for Q2 2020. 

whatsnew
Added release notes for Magento Open Source 1.9.4.5 and Magento Commerce 1.1.4.5. See
https://devdocs.magento.com/guides/m1x/ce19-ee114/ee1.14_release-notes.html
https://devdocs.magento.com/guides/m1x/ce19-ee114/ce1.9_release-notes.html

